### PR TITLE
Updating TCPDF version to non vulnerable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.4 || ^8.0",
         "ext-mbstring": "*",
         "ext-gd": "*",
-        "tecnickcom/tcpdf": "^6.6"
+        "tecnickcom/tcpdf": "^6.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",


### PR DESCRIPTION
html2pdf is using an older insecure version of TCPDF. Snyk has flagged that the version we’re on has 5 critical vulnerabilities that can be mitigated by updating the dependencies version to 6.8